### PR TITLE
Update colophon.xhtml

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -26,7 +26,7 @@
 			<a href="https://catalog.hathitrust.org/Record/006155757">HathiTrust Digital Library</a>.</p>
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">Hollingbourne, Kent</i>,<br/>
-			a painting by<br/>
+			a painting completed in 1906 by<br/>
 			<a href="https://en.wikipedia.org/wiki/Helen_Allingham">Helen Allingham</a>.<br/>
 			The cover and title pages feature the<br/>
 			<b epub:type="se:name.visual-art.typeface">League Spartan</b> and <b epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</b><br/>


### PR DESCRIPTION
Added the year of completion (1906) of the cover page artwork (Hollingbourne, Kent).

**Source:**
https://standardebooks.org/artworks/helen-allingham/hollingbourne-kent